### PR TITLE
Feature: periodic file cleansing

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -18,10 +18,10 @@ function FileCache (options) {
   this.directoryChunkSize = (options.directoryChunkSize && _.isFinite(options.directoryChunkSize)) ? options.directoryChunkSize : 0
   this.ttl = options.ttl || 3600
   this.cleanseInterval = options.cleanseInterval || 300
-
+  this.cleanseEnabled = options.cleanseEnabled || false
   this.encoding = 'utf-8'
 
-  if (options.cleanseEnabled) {
+  if (this.cleanseEnabled) {
     this.enableCacheCleansing()
   }
 
@@ -124,12 +124,24 @@ FileCache.prototype.getCachePath = function getCachePath(key) {
  */
 FileCache.prototype.enableCacheCleansing = function enableCacheCleansing() {
   var timeoutTrigger = () => {
-    setTimeout(() => {
-      this.cleanseCache(this.directory, timeoutTrigger)
+    this.cleanseTimeout = setTimeout(() => {
+      this.cleanseEnabled && this.cleanseCache(this.directory, timeoutTrigger)
     }, this.cleanseInterval * 1000)
   }
 
   timeoutTrigger()
+}
+
+/**
+ * disableCacheCleansing - stops and cleans up the timeout for cache cleansing
+ *
+ * @returns {void}
+ */
+FileCache.prototype.disableCacheCleansing = function enableCacheCleansing() {
+  this.cleanseEnabled = false
+  if (this.cleanseTimeout) {
+    clearTimeout(this.cleanseTimeout)
+  }
 }
 
 /**

--- a/lib/file.js
+++ b/lib/file.js
@@ -30,7 +30,7 @@ function FileCache (options) {
  * @returns {Promise.<Stream, Error>} A promise that returns a Stream if the key exists,
  *     or an Error if it does not exist
  */
-FileCache.prototype.get = function (key) {
+FileCache.prototype.get = function get(key) {
   return new Promise((resolve, reject) => {
     var cachePath = this.getCachePath(key)
 
@@ -57,7 +57,7 @@ FileCache.prototype.get = function (key) {
  * @param {String|Buffer|Stream} data - the data to cache, as a String, Buffer or Stream
  * @returns {Promise.<String, Error>} A promise that returns an empty String if successful, otherwise an Error
  */
-FileCache.prototype.set = function (key, data) {
+FileCache.prototype.set = function set(key, data) {
   return new Promise((resolve, reject) => {
     var cachePath = this.getCachePath(key)
 
@@ -83,7 +83,7 @@ FileCache.prototype.set = function (key, data) {
   })
 }
 
-FileCache.prototype.getCachePath = function (key) {
+FileCache.prototype.getCachePath = function getCachePath(key) {
   var folderPath = ''
 
   // split cache key into chunks to create folders

--- a/lib/file.js
+++ b/lib/file.js
@@ -166,7 +166,7 @@ FileCache.prototype.cleanseCache = function cleanseCache(dir, done) {
 
         var lastModified = stats && stats.mtime && stats.mtime.valueOf()
 
-        if (this.ttl && lastModified && (Date.now() - lastModified) / 1000 > this.ttl) {
+        if (lastModified && (Date.now() - lastModified) / 1000 > this.ttl) {
           fs.unlinkSync(file)
         }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -5,6 +5,7 @@ var path = require('path')
 var Stream = require('stream')
 var streamifier = require('streamifier')
 var recursive = require('recursive-readdir')
+var log = require('@dadi/logger')
 
 /**
  * Creates a new FileCache instance
@@ -152,7 +153,8 @@ FileCache.prototype.disableCacheCleansing = function disableCacheCleansing() {
 FileCache.prototype.cleanseCache = function cleanseCache(dir, done) {
   recursive(dir, (recursiveErr, files) => {
     if (recursiveErr) {
-      throw recursiveErr
+      log.error(recursiveErr)
+      return
     }
 
     var count = files.length
@@ -161,7 +163,8 @@ FileCache.prototype.cleanseCache = function cleanseCache(dir, done) {
     files.forEach((file) => {
       fs.stat(file, (statErr, stats) => {
         if (statErr) {
-          throw statErr
+          log.error(statErr)
+          return
         }
 
         var lastModified = stats && stats.mtime && stats.mtime.valueOf()

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,9 +1,10 @@
+var _ = require('underscore')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 var path = require('path')
 var Stream = require('stream')
 var streamifier = require('streamifier')
-var _ = require('underscore')
+var recursive = require('recursive-readdir')
 
 /**
  * Creates a new FileCache instance
@@ -16,8 +17,13 @@ function FileCache (options) {
   this.extension = options.extension ? '.' + options.extension : ''
   this.directoryChunkSize = (options.directoryChunkSize && _.isFinite(options.directoryChunkSize)) ? options.directoryChunkSize : 0
   this.ttl = options.ttl || 3600
+  this.cleanseInterval = options.cleanseInterval || 300
 
   this.encoding = 'utf-8'
+
+  if (options.cleanseEnabled) {
+    this.enableCacheCleansing()
+  }
 
   mkdirp(this.directory, (err, made) => {
     // if (err) log.error({module: 'cache'}, err)
@@ -83,6 +89,11 @@ FileCache.prototype.set = function set(key, data) {
   })
 }
 
+
+/**
+ * @param  {String} key - the key to store the data against
+ * @returns {String}
+ */
 FileCache.prototype.getCachePath = function getCachePath(key) {
   var folderPath = ''
 
@@ -104,8 +115,62 @@ FileCache.prototype.getCachePath = function getCachePath(key) {
   return path.resolve(path.join(folderPath, key + this.extension))
 }
 
+
+
 /**
+ * enableCacheCleansing - sets up and manages the timeout for cache cleansing
  *
+ * @returns {void}
+ */
+FileCache.prototype.enableCacheCleansing = function enableCacheCleansing() {
+  var timeoutTrigger = () => {
+    setTimeout(() => {
+      this.cleanseCache(this.directory, timeoutTrigger)
+    }, this.cleanseInterval * 1000)
+  }
+
+  timeoutTrigger()
+}
+
+/**
+ * cleanseCache - trawls cache files and removes any that have expired
+ *
+ * @param {String} directory path to cleanse
+ * @param {callback} done
+ * @returns {void}
+ */
+FileCache.prototype.cleanseCache = function cleanseCache(dir, done) {
+  recursive(dir, (recursiveErr, files) => {
+    if (recursiveErr) {
+      throw recursiveErr
+    }
+
+    var count = files.length
+    var idx = 0
+
+    files.forEach((file) => {
+      fs.stat(file, (statErr, stats) => {
+        if (statErr) {
+          throw statErr
+        }
+
+        var lastModified = stats && stats.mtime && stats.mtime.valueOf()
+
+        if (this.ttl && lastModified && (Date.now() - lastModified) / 1000 > this.ttl) {
+          fs.unlinkSync(file)
+        }
+
+        if (++idx === count) {
+          done()
+        }
+      })
+    })
+  })
+}
+
+/**
+ * @param  {Object} options
+ * @returns {FileCache} new instance of FileCache
  */
 module.exports = function (options) {
   return new FileCache(options)

--- a/lib/file.js
+++ b/lib/file.js
@@ -115,8 +115,6 @@ FileCache.prototype.getCachePath = function getCachePath(key) {
   return path.resolve(path.join(folderPath, key + this.extension))
 }
 
-
-
 /**
  * enableCacheCleansing - sets up and manages the timeout for cache cleansing
  *
@@ -137,7 +135,7 @@ FileCache.prototype.enableCacheCleansing = function enableCacheCleansing() {
  *
  * @returns {void}
  */
-FileCache.prototype.disableCacheCleansing = function enableCacheCleansing() {
+FileCache.prototype.disableCacheCleansing = function disableCacheCleansing() {
   this.cleanseEnabled = false
   if (this.cleanseTimeout) {
     clearTimeout(this.cleanseTimeout)

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,8 +34,14 @@ log.init({
  */
 function Cache (options) {
   contract.check(options, {
-    directory: [ { validator: 'required'}, { validator:'type', args: ['object']}],
-    redis: [ { validator: 'required'}, { validator:'type', args: ['object']}]
+    directory: [
+      { validator: 'required' },
+      { validator: 'type', args: ['object'] }
+    ],
+    redis: [
+      { validator: 'required' },
+      { validator: 'type', args: ['object'] }
+    ]
     // type: [{validator: 'required'}, {validator: 'custom', args:[function x() {
     //   if (options.type === 'directory' && !options.path) return false
     //   if (options.type === 'redis' && !options.host) return false

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dbc": "^3.0.0",
     "ioredis": "^2.2.0",
     "mkdirp": "^0.5.1",
+    "recursive-readdir": "^2.0.0",
     "redis": "^2.6.2",
     "redis-rstream": "^0.1.2",
     "redis-wstream": "^0.2.5",

--- a/test/unit/redis.js
+++ b/test/unit/redis.js
@@ -39,9 +39,10 @@ describe('RedisCache', function () {
       // new cache with incorrect configuration
       cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6378 } })
       cache.set('key1', 'data')
+
       // check a file exists
       fs.stat(path.resolve(path.join(cache.cacheHandler.directory, 'key1.json')), (err, stats) => {
-        stats.should.exist
+        should.exist(stats)
         done()
       })
     })


### PR DESCRIPTION
### Issue

Issue: #4 

### Notes

I created some test files to test this with. It ran pretty smoothly. It's async for the most part other than unlinking, but that's a pretty quick op.

```bash
# create 17576 files within 26^2 directories
mkdir -p {a..z}/{a..z}
touch {a..z}/{a..z}/{a..z}
```

### Tests

```
  28 passing (4s)
  3 pending

-----------|----------|----------|----------|----------|----------------|
File       |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------|----------|----------|----------|----------|----------------|
 lib/      |    88.83 |    83.53 |    86.96 |    89.11 |                |
  file.js  |    92.68 |    86.54 |      100 |    93.83 |... 112,157,166 |
  index.js |    96.15 |    84.62 |    85.71 |       96 |        119,130 |
  redis.js |    79.17 |       75 |       75 |    78.87 |... 139,140,141 |
-----------|----------|----------|----------|----------|----------------|
All files  |    88.83 |    83.53 |    86.96 |    89.11 |                |
-----------|----------|----------|----------|----------|----------------|


=============================== Coverage summary ===============================
Statements   : 88.83% ( 183/206 )
Branches     : 83.53% ( 71/85 )
Functions    : 86.96% ( 20/23 )
Lines        : 89.11% ( 180/202 )
================================================================================

```