### PR TITLE
feat: move redis flush to slave process

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -11,6 +11,7 @@ const redisWStream = require('redis-wstream')
 const Stream = require('stream')
 const streamifier = require('streamifier')
 const util = require('util')
+const cluster = require('cluster')
 
 // replace the SCAN methods for any node_redis
 require('node-redis-streamify')(noderedis)
@@ -248,14 +249,23 @@ RedisCache.prototype.setData = function (key, data, ttl) {
  * @returns {Promise.<String, Error>} A promise that returns an empty String if successful, otherwise an Error
  */
 RedisCache.prototype.flush = function (matchPattern) {
-  debug('FLUSH %s', matchPattern)
-
-  // if ((this.redisClient.status && this.redisClient.status !== 'ready') || !this.redisClient.ready) {
-  //   this.emit('fail', 'flush', matchPattern)
-  // }
-
   return new Promise((resolve, reject) => {
-    try {
+    if (cluster.isMaster) {
+      // If we're running as the master, then we want to fork the process once. We will send the
+      // options as well as matchPattern to the slave process and wait for a response.
+      const slave = cluster.fork()
+      slave.on('message', (msg) => {
+        const result = JSON.parse(msg)
+        if (result.success) resolve()
+        else reject(result.error)
+      })
+      slave.send(JSON.stringify({
+        options: this.options,
+        matchPattern: matchPattern
+      }))
+    } else {
+      // If we're running as the slave, then we'll have been called by SlaveFlushCache() below.
+      // The below logic is the original flush logic, which clears the flush.
       var keys = []
 
       if (this.redisClient.scanStream) {
@@ -283,8 +293,6 @@ RedisCache.prototype.flush = function (matchPattern) {
           })
         })
       }
-    } catch (err) {
-      return reject(err)
     }
   })
 }
@@ -318,6 +326,45 @@ RedisCache.prototype.onFailure = function onFailure() {
   //   this.emit('message', 'REDIS attempting reconnection')
   //   this.redisClient = this.initialise(this.options)
   // }, redisRetryTime)
+}
+
+// This function will run once cluster.fork() is ran, and waits for a message
+// from the master process (in RedisCache.prototype.flush). The message contains
+// the options used to initialise the redis client, as well as the matchPattern
+// to pass back to RedisCache.prototype.flush. Once complete, we send a message
+// back to the master process which will then complete it's promise.
+function SlaveFlushCache() {
+  debug('[' + process.pid + ']', 'SLAVE INIT')
+
+  process.on('message', (msg) => {
+    debug('[' + process.pid + ']', 'SLAVE MSG', msg)
+    const args = JSON.parse(msg)
+    const cache = new RedisCache(args.options)
+    const result = {}
+    cache
+      .flush(args.matchPattern)
+      .then(() => {
+        debug('[' + process.pid + ']', 'FLUSH DONE')
+        process.send(JSON.stringify({
+          success: true
+        }))
+        process.exit()
+      })
+      .catch((err) => {
+        debug('[' + process.pid + ']', 'FLUSH ERROR', err)
+        process.send(JSON.stringify({
+          success: false,
+          error: err
+        }))
+        process.exit()
+      })
+  })
+}
+
+// Check with each execution whether or not we're a slave process
+// and if we are, call a function that kicks off the flush process
+if (!cluster.isMaster) {
+  SlaveFlushCache()
 }
 
 module.exports = function (options) {


### PR DESCRIPTION
This PR addresses the bottleneck of flushing a redis cache on the same thread. It works by utilising `cluster` to fork the redis file once, communicating with the slave process via `process.send` and `process.on('message', function (msg) {})`.

The process is as follows:
```
[MASTER] [module]           init new RedisCache(options)
[MASTER] [module]           call RedisCache.flush(pattern)
[MASTER] [RedisCache.flush] call cluster.fork()
[MASTER] [RedisCache.flush] wait for message
[SLAVE]  [global]           call SlaveFlushCache()
[SLAVE]  [SlaveFlushCache]  wait for message
[MASTER] [RedisCache.flush] call slave.send(JSON({ options, pattern })) 
[SLAVE]  [SlaveFlushCache]  receive message JSON({ options, pattern })
[SLAVE]  [SlaveFlushCache]  init new RedisCache(options)
[SLAVE]  [SlaveFlushCache]  call RedisCache.flush(pattern)
[SLAVE]  [RedisCache.flush] flush cache, resolve/reject promise
[SLAVE]  [SlaveFlushCache]  call process.send(JSON({ success: true/false, error? })) 
[MASTER] [RedisCache.flush] receive message JSON({ success: true/false, error? })
[MASTER] [RedisCache.flush] resolve/reject promise
```

Things to think about:
- if a slave process initialises the redis library, will `cluster.isMaster` always be false?