### PR TITLE
Add support for metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ node_js:
   - '9'
   - '8'
   - '6'
-after_success:
-  - npm run travis-deploy-once "npm run semantic-release"
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DADI Cache
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/cache.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/cache)
-[![coverage](https://img.shields.io/badge/coverage-68%25-yellow.svg?style=flat-square)](https://github.com/dadi/cache)
+[![coverage](https://img.shields.io/badge/coverage-73%25-yellow.svg?style=flat)](https://github.com/dadi/cache)
 [![Build Status](https://travis-ci.org/dadi/cache.svg?branch=master)](https://travis-ci.org/dadi/cache)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)

--- a/lib/file.js
+++ b/lib/file.js
@@ -91,9 +91,7 @@ FileCache.prototype.getMetadata = function getMetadata (key) {
       return match.$dadiCache
     }
 
-    return Promise.reject(
-      new Error('The specified key does not have any metadata')
-    )
+    return null
   })
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -4,6 +4,7 @@ const debug = require('debug')('cache:file')
 const deleteEmpty = require('remove-empty-directories')
 const EventEmitter = require('events')
 const fs = require('fs')
+const Loki = require('lokijs')
 const path = require('path')
 const mkdirp = require('mkdirp')
 const Stream = require('stream')
@@ -29,6 +30,8 @@ function FileCache (options) {
   if (this.autoFlush) {
     this.enableAutoFlush()
   }
+
+  this.db = this.startDatabase()
 
   fs.stat(this.directory, (err) => {
     if (err) {
@@ -73,6 +76,28 @@ FileCache.prototype.get = function get (key, options) {
 }
 
 /**
+ * Gets a block of metadata for a given key, parsing it as JSON. Waits for the
+ * internal database to be initialised and become available.
+ *
+ * @param  {String} key - cache key
+ * @return {Promise.<Object, Error>} A promise that returns the metadata block if it exists,
+ *    or an Error otherwise.
+ */
+FileCache.prototype.getMetadata = function getMetadata (key) {
+  return this.db.then(db => {
+    let match = db.findOne({ $key: key })
+
+    if (match && match.$dadiCache) {
+      return match.$dadiCache
+    }
+
+    return Promise.reject(
+      new Error('The specified key does not have any metadata')
+    )
+  })
+}
+
+/**
  * @param {String} key - the key to store the data against
  * @param {String|Buffer|Stream} data - the data to cache, as a String, Buffer or Stream
  * @returns {Promise.<String, Error>} A promise that returns an empty String if successful, otherwise an Error
@@ -102,6 +127,33 @@ FileCache.prototype.set = function set (key, data, options) {
     }
 
     stream.pipe(cacheFile)
+  }).then(result => {
+    if (!options.metadata) {
+      return result
+    }
+
+    return this.setMetadata(key, options.metadata).then(() => result)
+  })
+}
+
+/**
+ * Saves a block of metadata for a given key. Waits for the internal database
+ * to be initialised and become available.
+ *
+ * @param {String} key - cache key
+ * @param {Object} data - metadata payload
+ * @returns {Promise.<Arrayr>} A promise that returns the inserted data
+ */
+FileCache.prototype.setMetadata = function setMetadata (key, data) {
+  return this.db.then(db => {
+    db.findAndRemove({ $key: key })
+
+    let insert = db.insert({
+      $dadiCache: data,
+      $key: key
+    })
+
+    return insert
   })
 }
 
@@ -151,6 +203,11 @@ FileCache.prototype.flush = function (pattern) {
           }
         })
       })
+    })
+
+    // Remove metadata.
+    this.db.then(db => {
+      db.findAndRemove({ $key: { $regex: re } })
     })
   })
 }
@@ -217,7 +274,7 @@ FileCache.prototype.disableAutoFlush = function disableAutoFlush () {
 }
 
 /**
- * Trawls a cache directory and removes any  cache files that have expired
+ * Trawls a cache directory and removes any cache files that have expired
  * and removes empty directories when finished.
  *
  * @param {String} directory path to cleanse
@@ -252,6 +309,33 @@ FileCache.prototype.cleanseCache = function cleanseCache (dir, done) {
         }
       })
     })
+  })
+}
+
+/**
+ * Fires up the internal database, loading any existing data from disk.
+ *
+ * @return {Promise<Collection>} Instance of initialised LokiJS collection
+ */
+FileCache.prototype.startDatabase = function () {
+  return new Promise((resolve, reject) => {
+    let db = new Loki(
+      path.join(__dirname, '../db.json'),
+      {
+        autoload: true,
+        autoloadCallback: () => {
+          let collection = db.getCollection('cache')
+
+          if (collection === null) {
+            collection = db.addCollection('cache')
+          }
+
+          resolve(collection)
+        },
+        autosave: true, 
+        autosaveInterval: 1000
+      }
+    )    
   })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,16 @@ Cache.prototype.get = function (key, options) {
 }
 
 /**
+ * Get any metadata stored for a key
+ * @param {String} key - the key used to reference the item in the cache
+ * @returns {Promise.<Object, Error>} A promise that returns an object if there is metadata
+ *     for the given key, or an Error otherwise
+ */
+Cache.prototype.getMetadata = function (key) {
+  return this.cacheHandler.getMetadata(key)
+}
+
+/**
  * Add an item to the cache
  * @param {String} key - the key used to reference the item in the cache
  * @param {Buffer|Stream|String} data - the data to store in the cache
@@ -100,8 +110,10 @@ Cache.prototype.flush = function (path) {
  * @returns {FileCache}
  */
 Cache.prototype.createFileCache = function (options, ttl) {
-  options.ttl = ttl
-  var handler = new FileCache(options)
+  let handler = new FileCache(Object.assign({}, options, {
+    ttl
+  }))
+
   this.cacheHandlers.directory = handler
 
   this.emit('message', 'FileCache connected')
@@ -117,8 +129,9 @@ Cache.prototype.createFileCache = function (options, ttl) {
  * @returns {RedisCache}
  */
 Cache.prototype.createRedisCache = function (options, ttl) {
-  options.ttl = ttl
-  var handler = new RedisCache(options)
+  let handler = new RedisCache(Object.assign({}, options, {
+    ttl
+  }))
 
   handler.on('ready', () => { // when we are connected
     if (this.cacheHandler.constructor.name === 'FileCache') {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -171,35 +171,35 @@ RedisCache.prototype.get = function get (key, options) {
 /**
  * Get any metadata stored for a key
  * @param {String} key - the key used to reference the item in the cache
- * @returns {Promise.<Object, Error>} A promise that returns an object if there is metadata
- *     for the given key, or an Error otherwise
+ * @returns {Promise.<Object>} A promise that returns an object if there is metadata
+ *     for the given key, or null otherwise
  */
 RedisCache.prototype.getMetadata = function getMetadata (key) {
   let metadataKey = this.getMetadataKey(key)
 
   return new Promise((resolve, reject) => {
     this.redisClient.exists(metadataKey, (err, exists) => {
-      if (exists > 0) {
-        this.redisClient.get(metadataKey, (err, res) => {
-          if (err) {
-            if (err.message) {
-              throw err
-            }
-
-            throw new Error(err)
-          }
-
-          try {
-            let parsed = JSON.parse(res)
-
-            resolve(parsed)
-          } catch (err) {
-            reject(err)
-          }
-        })
-      } else {
-        return reject(new Error('The specified key does not have any metadata'))
+      if (exists === 0) {
+        return resolve(null)
       }
+
+      this.redisClient.get(metadataKey, (err, res) => {
+        if (err) {
+          if (err.message) {
+            throw err
+          }
+
+          throw new Error(err)
+        }
+
+        try {
+          let parsed = JSON.parse(res)
+
+          resolve(parsed)
+        } catch (err) {
+          reject(err)
+        }
+      })      
     })
   })  
 }

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -169,6 +169,52 @@ RedisCache.prototype.get = function get (key, options) {
 }
 
 /**
+ * Get any metadata stored for a key
+ * @param {String} key - the key used to reference the item in the cache
+ * @returns {Promise.<Object, Error>} A promise that returns an object if there is metadata
+ *     for the given key, or an Error otherwise
+ */
+RedisCache.prototype.getMetadata = function getMetadata (key) {
+  let metadataKey = this.getMetadataKey(key)
+
+  return new Promise((resolve, reject) => {
+    this.redisClient.exists(metadataKey, (err, exists) => {
+      if (exists > 0) {
+        this.redisClient.get(metadataKey, (err, res) => {
+          if (err) {
+            if (err.message) {
+              throw err
+            }
+
+            throw new Error(err)
+          }
+
+          try {
+            let parsed = JSON.parse(res)
+
+            resolve(parsed)
+          } catch (err) {
+            reject(err)
+          }
+        })
+      } else {
+        return reject(new Error('The specified key does not have any metadata'))
+      }
+    })
+  })  
+}
+
+/**
+ * Computes a key to use for the metadata associated with
+ * a key
+ * @param  {String} key
+ * @return {String}
+ */
+RedisCache.prototype.getMetadataKey = function (key) {
+  return `___${key}___`
+}
+
+/**
  *
  */
 RedisCache.prototype.set = function set (key, data, options) {
@@ -225,6 +271,16 @@ RedisCache.prototype.set = function set (key, data, options) {
 
       stream.pipe(redisWriteStream)
     }
+  }).then(result => {
+    if (!options.metadata) {
+      return result
+    }
+
+    return this.setData(
+      this.getMetadataKey(key),
+      JSON.stringify(options.metadata),
+      options.ttl
+    ).then(() => result)
   })
 }
 
@@ -249,19 +305,18 @@ RedisCache.prototype.setData = function (key, data, ttl) {
 RedisCache.prototype.flush = function (matchPattern) {
   debug('FLUSH %s', matchPattern)
 
-  // if ((this.redisClient.status && this.redisClient.status !== 'ready') || !this.redisClient.ready) {
-  //   this.emit('fail', 'flush', matchPattern)
-  // }
-
   return new Promise((resolve, reject) => {
     try {
-      var keys = []
+      let keys = []
 
       if (this.redisClient.scanStream) {
-        var stream = this.redisClient.scanStream({ match: matchPattern || '' })
+        let stream = this.redisClient.scanStream({ match: matchPattern || '' })
 
-        stream.on('data', (resultKeys) => {
-          resultKeys.forEach((key) => { keys.push(key) })
+        stream.on('data', resultKeys => {
+          resultKeys.forEach(key => {
+            keys.push(key)
+            keys.push(this.getMetadataKey(key))
+          })
         })
 
         stream.on('end', () => {
@@ -270,11 +325,12 @@ RedisCache.prototype.flush = function (matchPattern) {
           })
         })
       } else {
-        var scan = this.redisClient.streamified('SCAN')
+        let scan = this.redisClient.streamified('SCAN')
 
-        scan(matchPattern || '*').on('data', (data) => {
+        scan(matchPattern || '*').on('data', data => {
           keys.push(data)
-        }).on('error', (err) => {
+          keys.push(this.getMetadataKey(data))
+        }).on('error', err => {
           return reject(err)
         }).on('end', () => {
           this.deleteKeys(keys).then(() => {
@@ -291,7 +347,7 @@ RedisCache.prototype.flush = function (matchPattern) {
 RedisCache.prototype.deleteKeys = function (keys) {
   return new Promise((resolve, reject) => {
     if (keys.length > 0) {
-      var i = 0
+      let i = 0
 
       keys.forEach(key => {
         this.redisClient.del(key, (err, result) => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "debug": "^2.6.1",
     "deepmerge": "^2.1.0",
     "ioredis": "2.5.0",
+    "lokijs": "^1.5.3",
     "mkdirp": "0.5.1",
     "node-redis-streamify": "0.1.6",
     "recursive-readdir": "2.1.1",

--- a/test/unit/file.js
+++ b/test/unit/file.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec
 var fs = require('fs')
+var fsExtra = require('fs-extra')
 var path = require('path')
 var should = require('should')
 var sinon = require('sinon')
@@ -163,6 +164,156 @@ describe('FileCache', function () {
       fs.stat(cache.cacheHandler.directory + '/key1.json', (err, stats) => {
         (!err).should.eql(true)
         done()
+      })
+    })
+  })
+
+  describe('metadata', function () {
+    this.timeout(5000)
+
+    let cache
+    let metadata = {
+      foo: 'bar',
+      baz: 123
+    }
+
+    beforeEach(done => {
+      cache = new Cache({
+        directory: {
+          enabled: true,
+          path: './cache',
+          extension: 'json'
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+
+      setTimeout(done, 2000)
+    })
+
+    afterEach(() => {
+      fsExtra.removeSync(
+        path.join(__dirname, './../../db.json')
+      )
+    })
+
+    it('should save metadata alongside a String payload', () => {
+      return cache.set('key1', 'data', { metadata }).then(() => {
+        return cache.get('key1')
+      }).then(result => {
+        should.exist(result)
+
+        return cache.getMetadata('key1')
+      }).then(result => {
+        result.should.eql(metadata)
+      })
+    })
+
+    it('should save metadata alongside a Buffer payload', () => {
+      let buffer = new Buffer('data')
+
+      return cache.set('key1', buffer, { metadata }).then(() => {
+        return cache.get('key1')
+      }).then(result => {
+        should.exist(result)
+
+        return cache.getMetadata('key1')
+      }).then(result => {
+        result.should.eql(metadata)
+      })
+    })
+
+    it('should save metadata alongside a Stream payload', () => {
+      let stream = new Stream.Readable()
+      stream.push('data')
+      stream.push(null)
+
+      return cache.set('key1', stream, { metadata }).then(() => {
+        return cache.get('key1')
+      }).then(result => {
+        return cache.getMetadata('key1')
+      }).then(result => {
+        result.should.eql(metadata)
+      })
+    })
+
+    it('should persist metadata database to disk and reload it on instantiation', () => {
+      return cache.set('key1', 'data', { metadata }).then(() => {
+        return cache.get('key1')
+      }).then(result => {
+        return cache.getMetadata('key1')
+      }).then(result => {
+        result.should.eql(metadata)
+
+        return new Promise((resolve, reject) => {
+          setTimeout(resolve, 1500)
+        }).then(() => {
+          let newCache = new Cache({
+            directory: {
+              enabled: true,
+              path: './cache',
+              extension: 'json'
+            },
+            redis: {
+              enabled: false,
+              host: '127.0.0.1',
+              port: 6379
+            }
+          })
+
+          return cache.getMetadata('key1')
+        }).then(result => {
+          result.should.eql(metadata)
+        })
+      })
+    })
+
+    it('should delete any metadata associated with a key when it\'s flushed', done => {
+      cache.set('key2', 'data', { metadata }).then(() => {
+        return cache.get('key2')
+      }).then(stream => {
+        should.exist(stream)
+
+        return cache.getMetadata('key2')
+      }).then(result => {
+        result.should.eql(metadata)
+
+        return cache.flush('key*')
+      }).then(() => {
+        return cache.get('key2').catch(err => {
+          err.message.should.eql(
+            'The specified key does not exist'
+          )
+
+          return cache.getMetadata('key2').catch(err => {
+            err.message.should.eql(
+              'The specified key does not have any metadata'
+            )
+
+            done()
+          })
+        })
+      })
+    })
+
+    it('should not delete metadata associated with a key when another key is flushed', () => {
+      cache.set('key3', 'data', { metadata }).then(() => {
+        return cache.get('key3')
+      }).then(stream => {
+        should.exist(stream)
+
+        return cache.getMetadata('key3')
+      }).then(result => {
+        result.should.eql(metadata)
+
+        return cache.flush('key2')
+      }).then(() => {
+        return cache.get('key3')
+      }).then(result => {
+        result.should.eql(metadata)
       })
     })
   })

--- a/test/unit/file.js
+++ b/test/unit/file.js
@@ -288,10 +288,8 @@ describe('FileCache', function () {
             'The specified key does not exist'
           )
 
-          return cache.getMetadata('key2').catch(err => {
-            err.message.should.eql(
-              'The specified key does not have any metadata'
-            )
+          return cache.getMetadata('key2').then(result => {
+            should.equal(result, null)
 
             done()
           })
@@ -314,6 +312,12 @@ describe('FileCache', function () {
         return cache.get('key3')
       }).then(result => {
         result.should.eql(metadata)
+      })
+    })
+
+    it('should return null when trying to get metadata for a key that doesn\'t have any', () => {
+      return cache.getMetadata('key-that-does-not-exist').then(result => {
+        should.equal(result, null)
       })
     })
   })

--- a/test/unit/redis.js
+++ b/test/unit/redis.js
@@ -300,13 +300,13 @@ describe('RedisCache', () => {
       })
     }))
 
-    it('should throw when there is no metadata for the given key', sinon.test(function (done) {
+    it('should return null when there is no metadata for the given key', sinon.test(function (done) {
       const client = new RedisMock()
       this.stub(noderedis, 'createClient').returns(client)
 
       cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
-      cache.getMetadata('key-that-does-not-exist').catch(err => {
-        err.message.should.eql('The specified key does not have any metadata')
+      cache.getMetadata('key-that-does-not-exist').then(err => {
+        should.equal(err, null)
 
         done()
       })

--- a/test/unit/redis.js
+++ b/test/unit/redis.js
@@ -51,6 +51,27 @@ describe('RedisCache', () => {
       done()
     }))
 
+    it('should add to Redis cache and save metadata when a String and options.metadata are passed', sinon.test(function (done) {
+      const client = new RedisMock()
+      this.stub(noderedis, 'createClient').returns(client)
+      const spy = this.spy(client, 'set')
+
+      let metadata = {
+        foo: 'bar',
+        baz: 123
+      }
+
+      cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
+      cache.set('key-string', 'data', { metadata }).then(() => {
+        spy.called.should.eql(true)
+        spy.firstCall.args[0].indexOf('key-string').should.be.above(-1)
+        spy.secondCall.args[0].should.eql('___key-string___')
+        spy.secondCall.args[1].should.eql(JSON.stringify(metadata))
+
+        done()
+      })
+    }))
+
     it('should add to Redis cache when a Buffer is passed', sinon.test(function (done) {
       const client = new RedisMock()
       this.stub(noderedis, 'createClient').returns(client)
@@ -63,6 +84,29 @@ describe('RedisCache', () => {
       spy.called.should.eql(true)
       spy.firstCall.args[0].indexOf('key-buffer').should.be.above(-1)
       done()
+    }))
+
+    it('should add to Redis cache and save metadata when a Buffer and options.metadata are passed', sinon.test(function (done) {
+      const client = new RedisMock()
+      this.stub(noderedis, 'createClient').returns(client)
+      const spy = this.spy(client, 'set')
+
+      let metadata = {
+        foo: 'bar',
+        baz: 123
+      }
+
+      cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
+      cache.set('key-buffer', new Buffer('data'), { metadata }).then(() => {
+        // check params passed to SET
+        spy.called.should.eql(true)
+        spy.firstCall.args[0].indexOf('key-buffer').should.be.above(-1)
+
+        spy.secondCall.args[0].should.eql('___key-buffer___')
+        spy.secondCall.args[1].should.eql(JSON.stringify(metadata))
+
+        done()        
+      })
     }))
 
     it('should add to Redis cache when a Stream is passed', sinon.test(function (done) {
@@ -81,6 +125,33 @@ describe('RedisCache', () => {
       spy.called.should.eql(true)
       spy.firstCall.args[0].indexOf('key-stream').should.be.above(-1)
       done()
+    }))
+
+    it('should add to Redis cache and save metadata when a Stream and options.metadata are passed', sinon.test(function (done) {
+      const client = new RedisMock()
+      this.stub(noderedis, 'createClient').returns(client)
+      const spy = this.spy(client, 'set')
+
+      let metadata = {
+        foo: 'bar',
+        baz: 123
+      }
+
+      cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
+
+      const stream = new Stream.Readable()
+      stream.push('data')
+      stream.push(null)
+      cache.set('key-stream', stream, { metadata }).then(() => {
+        // check params passed to SET
+        spy.called.should.eql(true)
+        spy.firstCall.args[0].indexOf('key-stream').should.be.above(-1)
+
+        spy.secondCall.args[0].should.eql('___key-stream___')
+        spy.secondCall.args[1].should.eql(JSON.stringify(metadata))
+
+        done()
+      })
     }))
 
     it('should set and return binary data', sinon.test(function (done) {
@@ -204,6 +275,78 @@ describe('RedisCache', () => {
         })
       }).catch((err) => {
         console.log(err)
+      })
+    }))
+  })
+
+  describe('getMetadata', function () {
+    it('should return and parse metadata', sinon.test(function (done) {
+      const client = new RedisMock()
+      this.stub(noderedis, 'createClient').returns(client)
+      const spy = this.spy(client, 'set')
+
+      let metadata = {
+        foo: 'bar',
+        baz: 123
+      }
+
+      cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
+      cache.set('key-string', 'data', { metadata }).then(() => {
+        cache.getMetadata('key-string').then(metadata => {
+          metadata.should.eql(metadata)
+
+          done()
+        })
+      })
+    }))
+
+    it('should throw when there is no metadata for the given key', sinon.test(function (done) {
+      const client = new RedisMock()
+      this.stub(noderedis, 'createClient').returns(client)
+
+      cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
+      cache.getMetadata('key-that-does-not-exist').catch(err => {
+        err.message.should.eql('The specified key does not have any metadata')
+
+        done()
+      })
+    }))
+  })
+
+  describe('flush', function () {
+    it('should delete the keys that match a given pattern, along with any associated metadata', sinon.test(function (done) {
+      let MockStreamified = function () {}
+
+      MockStreamified.prototype.on = function (event, handler) {
+        if (event === 'data') {
+          this.dataFn = handler
+        } else if (event === 'end') {
+          this.dataFn('test-key')
+
+          handler()
+        }
+
+        return this
+      }
+
+      RedisMock.prototype.streamified = function (method) {
+        let mockStreamified = new MockStreamified()
+
+        return () => mockStreamified
+      }
+
+      const client = new RedisMock()
+      this.stub(noderedis, 'createClient').returns(client)
+      const spy = this.spy(client, 'del')
+
+      cache = new Cache({ directory: { enabled: false, path: './cache', extension: 'json' }, redis: { enabled: true, host: '127.0.0.1', port: 6379 } })
+      cache.set('key-string', 'data').then(() => {
+        cache.flush('key-string').then(() => {
+          spy.firstCall.args[0].should.eql('test-key')
+          spy.secondCall.args[0].should.eql('___test-key___')
+
+          done()
+        })
       })
     }))
   })


### PR DESCRIPTION
This PR extends Cache with the ability to store an optional metadata alongside a payload of any type (Buffer, Stream or String).

## Saving metadata

Saving metadata happens at the point of adding something to cache. The `set()` method already takes an optional `options` object, which will now accept a `metadata` property. When set, this value will be JSON-stringified and saved internally (see *Implementation details*).

*Example:*

```js
// Caching a file without metadata (as used currently)
cache.set('my-key1', file1).then(() => {
  console.log('File has been cached')
}

// Caching a file with metadata
cache.set('my-key2', file2, {
  metadata: {
    author: 'John Doe',
    etag: '1q2w3e4r'
  }
})
```

## Reading metadata

Reading metadata happens via a new `getMetadata` method. It receives a key and returns a Promise that resolves with a parsed object if the given key has any associated metadata, otherwise returns `null`.

```js
// Getting a cached file (as used currently)
cache.get('my-key1').then(stream => {
  console.log('Cached:', stream)
})

// Getting a cached file and any associated metadata
cache.get('my-key2').then(stream => {
  return cache.getMetadata('my-key2').then(metadata => {
    if (metadata) {
      console.log('Metadata:', metadata)
    }

    console.log('Cached:', stream)
  })
})
```

## Internal implementation

The internal implementation varies with each adapter. In Redis, metadata for key `test` is stored as a String in another Redis key, named `__test__`. In the file adapter, an in-memory LokiJS database (persisted to disk every 1000ms) is used to map arbitrary JavaScript objects against cache keys.

## Use cases

This will unblock a series of issues. For example, in https://github.com/dadi/cdn/issues/235 we'll be able to store in the metadata block whether the asset has been gzipped before caching, allowing us to process it correctly on the way out. The same with https://github.com/dadi/cdn/issues/253.

Closes #24.