### PR TITLE
Remove default file encoding

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -25,7 +25,6 @@ function FileCache (options) {
   this.ttl = options.ttl || 3600
   this.autoFlushInterval = options.autoFlushInterval || 300
   this.autoFlush = options.autoFlush || false
-  this.encoding = 'utf-8'
 
   if (this.autoFlush) {
     this.enableAutoFlush()
@@ -61,12 +60,12 @@ FileCache.prototype.get = function get (key, options) {
         return reject(new Error('The specified key does not exist'))
       }
 
-      var lastModified = stats && stats.mtime && stats.mtime.valueOf()
+      let lastModified = stats && stats.mtime && stats.mtime.valueOf()
 
-      var ttl = options.ttl || this.ttl
+      let ttl = options.ttl || this.ttl
 
       if (ttl && lastModified && (Date.now() - lastModified) / 1000 <= ttl) {
-        var stream = fs.createReadStream(cachePath)
+        let stream = fs.createReadStream(cachePath)
         return resolve(stream)
       } else {
         return reject(new Error('The specified key has expired'))
@@ -104,10 +103,10 @@ FileCache.prototype.set = function set (key, data, options) {
   debug('SET %s %o', key, options)
 
   return new Promise((resolve, reject) => {
-    var cachePath = this.getCachePath(key, options)
+    let cachePath = this.getCachePath(key, options)
 
     // open a stream for writing the data
-    var cacheFile = fs.createWriteStream(cachePath, { flags: 'w', defaultEncoding: this.encoding })
+    let cacheFile = fs.createWriteStream(cachePath, { flags: 'w' })
 
     cacheFile.on('finish', () => {
       return resolve('')
@@ -115,7 +114,7 @@ FileCache.prototype.set = function set (key, data, options) {
       return reject(err)
     })
 
-    var stream
+    let stream
 
     // create a stream from the data if it is a String or Buffer
     if (data instanceof Buffer || typeof data === 'string') {
@@ -140,7 +139,7 @@ FileCache.prototype.set = function set (key, data, options) {
  *
  * @param {String} key - cache key
  * @param {Object} data - metadata payload
- * @returns {Promise.<Arrayr>} A promise that returns the inserted data
+ * @returns {Promise.<Array>} A promise that returns the inserted data
  */
 FileCache.prototype.setMetadata = function setMetadata (key, data) {
   return this.db.then(db => {
@@ -215,11 +214,11 @@ FileCache.prototype.flush = function (pattern) {
  * @returns {String}
  */
 FileCache.prototype.getCachePath = function getCachePath (key, options) {
-  var folderPath = ''
+  let folderPath = ''
 
   // split cache key into chunks to create folders
   if (this.directoryChunkSize > 0) {
-    var re = new RegExp('.{1,' + this.directoryChunkSize + '}', 'g')
+    let re = new RegExp('.{1,' + this.directoryChunkSize + '}', 'g')
     folderPath = key.match(re).join('/')
   }
 
@@ -232,7 +231,7 @@ FileCache.prototype.getCachePath = function getCachePath (key, options) {
     if (err.code !== 'EEXISTS') throw err
   }
 
-  var extension
+  let extension
 
   if (options.directory && options.directory.extension) {
     extension = options.directory.extension[0] === '.' ? options.directory.extension : '.' + options.directory.extension
@@ -249,7 +248,7 @@ FileCache.prototype.getCachePath = function getCachePath (key, options) {
  * @returns {void}
  */
 FileCache.prototype.enableAutoFlush = function enableAutoFlush () {
-  var timeoutTrigger = () => {
+  let timeoutTrigger = () => {
     this.autoFlushTimeout = setTimeout(() => {
       this.autoFlush && this.cleanseCache(this.directory, timeoutTrigger)
     }, this.autoFlushInterval * 1000)
@@ -295,7 +294,7 @@ FileCache.prototype.cleanseCache = function cleanseCache (dir, done) {
           return
         }
 
-        var lastModified = stats && stats.mtime && stats.mtime.valueOf()
+        let lastModified = stats && stats.mtime && stats.mtime.valueOf()
 
         if (lastModified && (Date.now() - lastModified) / 1000 > this.ttl) {
           fs.unlinkSync(file)
@@ -330,10 +329,10 @@ FileCache.prototype.startDatabase = function () {
 
           resolve(collection)
         },
-        autosave: true, 
+        autosave: true,
         autosaveInterval: 1000
       }
-    )    
+    )
   })
 }
 


### PR DESCRIPTION
This PR removes the default encoding passed to createWriteStream when using the file adapter. Previously set to utf-8, this encoding makes it difficult to store compressed data from core products.