### PR TITLE
Add in-memory index to file handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DADI Cache
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/cache.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/cache)
-[![coverage](https://img.shields.io/badge/coverage-73%25-yellow.svg?style=flat)](https://github.com/dadi/cache)
+[![coverage](https://img.shields.io/badge/coverage-71%25-yellow.svg?style=flat)](https://github.com/dadi/cache)
 [![Build Status](https://travis-ci.org/dadi/cache.svg?branch=master)](https://travis-ci.org/dadi/cache)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)

--- a/lib/file.js
+++ b/lib/file.js
@@ -107,8 +107,8 @@ FileCache.prototype.getMetadata = function getMetadata (key) {
   return this.db.then(db => {
     let match = db.findOne({ $key: key })
 
-    if (match && match.$dadiCache) {
-      return match.$dadiCache
+    if (match && match.metadata) {
+      return match.metadata
     }
 
     return null
@@ -142,10 +142,9 @@ FileCache.prototype.set = function set (key, data, options) {
 
     db.insert({
       $key: key,
-      $dadiCache: options.metadata || null,
+      metadata: options.metadata || null,
       lastModified,
-      path: cachePath,
-      metadata: options.metadata || null
+      path: cachePath
     })
 
     return new Promise((resolve, reject) => {
@@ -173,8 +172,8 @@ FileCache.prototype.setMetadata = function setMetadata (key, data) {
     db.findAndRemove({ $key: key })
 
     let insert = db.insert({
-      $dadiCache: data,
-      $key: key
+      $key: key,
+      metadata: data
     })
 
     return insert

--- a/lib/file.js
+++ b/lib/file.js
@@ -187,40 +187,35 @@ FileCache.prototype.setMetadata = function setMetadata (key, data) {
  * @returns {Promise.<String, Error>} A promise that returns an empty String if successful, otherwise an Error
  */
 FileCache.prototype.flush = function (pattern) {
-  return new Promise((resolve, reject) => {
-    let cachePath = path.resolve(this.directory)
-    let re = new RegExp(pattern)
+  let cachePath = path.resolve(this.directory)
+  let re = new RegExp(pattern)
 
-    recursive(cachePath, (recursiveErr, files) => {
-      if (recursiveErr) {
-        return reject(recursiveErr)
+  return this.db.then(db => {
+    let matches = db.find({ $key: { $regex: re } })
+    let deletedCount = 0
+
+    return new Promise((resolve, reject) => {
+      let registerDeletion = () => {
+        if (++deletedCount === matches.length) {
+          deleteEmpty(cachePath)
+
+          resolve()
+        }
       }
 
-      if (files.length === 0) {
-        return resolve('')
-      }
+      matches.forEach(match => {
+        if (!match.path) return
 
-      let matchingFiles = files.filter(file => {
-        return re.test(file)
+        try {
+          fs.unlink(match.path, registerDeletion)
+        } catch (err) {
+          console.log(err)
+
+          registerDeletion()
+        }
+
+        db.remove(match)
       })
-      let idx = 0
-
-      matchingFiles.forEach(file => {
-        let filepath = path.resolve(file)
-
-        fs.unlink(filepath, () => {
-          if (++idx === matchingFiles.length) {
-            deleteEmpty(cachePath)
-
-            return resolve('')
-          }
-        })
-      })
-    })
-
-    // Remove metadata.
-    this.db.then(db => {
-      db.findAndRemove({ $key: { $regex: re } })
     })
   })
 }
@@ -235,6 +230,7 @@ FileCache.prototype.getCachePath = function getCachePath (key, options) {
   // split cache key into chunks to create folders
   if (this.directoryChunkSize > 0) {
     let re = new RegExp('.{1,' + this.directoryChunkSize + '}', 'g')
+
     folderPath = key.match(re).join('/')
   }
 
@@ -295,33 +291,33 @@ FileCache.prototype.disableAutoFlush = function disableAutoFlush () {
  * @returns {void}
  */
 FileCache.prototype.cleanseCache = function cleanseCache (dir, done) {
-  recursive(dir, (recursiveErr, files) => {
-    if (recursiveErr) {
-      this.emit('error', recursiveErr)
-      return
-    }
+  return this.db.then(db => {
+    let matches = db.find()
+    let deletionQueue = []
 
-    let idx = 0
+    matches.forEach(match => {
+      if (!match.path) return
 
-    files.forEach((file) => {
-      fs.stat(file, (statErr, stats) => {
-        if (statErr) {
-          this.emit('error', statErr)
-          return
-        }
+      if (match.lastModified && (Date.now() - match.lastModified) / 1000 > this.ttl) {
+        deletionQueue.push(
+          new Promise((resolve, reject) => {
+            try {
+              fs.unlink(match.path, resolve)
+            } catch (err) {
+              console.log(err)
 
-        let lastModified = stats && stats.mtime && stats.mtime.valueOf()
+              resolve()
+            }
+          })
+        )
 
-        if (lastModified && (Date.now() - lastModified) / 1000 > this.ttl) {
-          fs.unlinkSync(file)
-        }
-
-        if (++idx === files.length) {
-          deleteEmpty(dir)
-          done()
-        }
-      })
+        db.remove(match)
+      }
     })
+
+    return Promise.all(deletionQueue)
+  }).then(() => {
+    deleteEmpty(dir)
   })
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -95,6 +95,9 @@ FileCache.prototype.get = function get (key, options) {
       })
 
       stream.on('error', () => {
+        // Removing key from database.
+        db.remove(match)
+
         reject(errorNotFound)
       })
     })

--- a/lib/file.js
+++ b/lib/file.js
@@ -160,27 +160,6 @@ FileCache.prototype.set = function set (key, data, options) {
 }
 
 /**
- * Saves a block of metadata for a given key. Waits for the internal database
- * to be initialised and become available.
- *
- * @param {String} key - cache key
- * @param {Object} data - metadata payload
- * @returns {Promise.<Array>} A promise that returns the inserted data
- */
-FileCache.prototype.setMetadata = function setMetadata (key, data) {
-  return this.db.then(db => {
-    db.findAndRemove({ $key: key })
-
-    let insert = db.insert({
-      $key: key,
-      metadata: data
-    })
-
-    return insert
-  })
-}
-
-/**
  * Removes cache files matching a specified pattern and removes empty directories when finished.
  *
  * @param {String} pattern

--- a/lib/file.js
+++ b/lib/file.js
@@ -86,9 +86,9 @@ FileCache.prototype.get = function get (key, options) {
       let stream = fs.createReadStream(match.path)
 
       // `fs.createReadStream` is asynchronous, so it will never
-      // fire an ENOENT if the file doesn't exist. As a result of
-      // that, we reply on the open/error events of the stream to
-      // determine whether the Promise resolves or rejects, rather
+      // fire an ENOENT error if the file doesn't exist. As a result
+      // of that, we rely on the open/error events of the stream to
+      // determine whether the Promise should resolve or reject, rather
       // than using a try/catch.
       stream.on('open', () => {
         resolve(stream)

--- a/lib/file.js
+++ b/lib/file.js
@@ -82,16 +82,22 @@ FileCache.prototype.get = function get (key, options) {
       return Promise.reject(errorNotFound)
     }
 
-    try {
+    return new Promise((resolve, reject) => {
       let stream = fs.createReadStream(match.path)
 
-      return stream
-    } catch (err) {
-      // Removing key from database.
-      db.remove(match)
+      // `fs.createReadStream` is asynchronous, so it will never
+      // fire an ENOENT if the file doesn't exist. As a result of
+      // that, we reply on the open/error events of the stream to
+      // determine whether the Promise resolves or rejects, rather
+      // than using a try/catch.
+      stream.on('open', () => {
+        resolve(stream)
+      })
 
-      return Promise.reject(errorNotFound)
-    }
+      stream.on('error', () => {
+        reject(errorNotFound)
+      })
+    })
   })
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -52,25 +52,46 @@ util.inherits(FileCache, EventEmitter)
 FileCache.prototype.get = function get (key, options) {
   debug('GET %s %o', key, options)
 
-  return new Promise((resolve, reject) => {
-    let cachePath = this.getCachePath(key, options)
+  let errorNotFound = new Error(
+    'The specified key does not exist'
+  )
 
-    fs.stat(cachePath, (err, stats) => {
-      if (err) {
-        return reject(new Error('The specified key does not exist'))
-      }
+  return this.db.then(db => {
+    let match = db.findOne({ $key: key })
 
-      let lastModified = stats && stats.mtime && stats.mtime.valueOf()
+    if (!match) {
+      return Promise.reject(errorNotFound)
+    }
 
-      let ttl = options.ttl || this.ttl
+    let lastModified = match.lastModified || 0
+    let ttl = options.ttl || this.ttl || 0
 
-      if (ttl && lastModified && (Date.now() - lastModified) / 1000 <= ttl) {
-        let stream = fs.createReadStream(cachePath)
-        return resolve(stream)
-      } else {
-        return reject(new Error('The specified key has expired'))
-      }
-    })
+    if ((Date.now() - lastModified) / 1000 > ttl) {
+      // Removing key from database.
+      db.remove(match)
+
+      return Promise.reject(
+        new Error('The specified key has expired')
+      )
+    }
+
+    if (!match.path) {
+      // Removing key from database.
+      db.remove(match)
+
+      return Promise.reject(errorNotFound)
+    }
+
+    try {
+      let stream = fs.createReadStream(match.path)
+
+      return stream
+    } catch (err) {
+      // Removing key from database.
+      db.remove(match)
+
+      return Promise.reject(errorNotFound)
+    }
   })
 }
 
@@ -102,34 +123,39 @@ FileCache.prototype.getMetadata = function getMetadata (key) {
 FileCache.prototype.set = function set (key, data, options) {
   debug('SET %s %o', key, options)
 
-  return new Promise((resolve, reject) => {
+  return this.db.then(db => {
+    db.findAndRemove({ $key: key })
+
     let cachePath = this.getCachePath(key, options)
-
-    // open a stream for writing the data
     let cacheFile = fs.createWriteStream(cachePath, { flags: 'w' })
-
-    cacheFile.on('finish', () => {
-      return resolve('')
-    }).on('error', (err) => {
-      return reject(err)
-    })
-
     let stream
 
-    // create a stream from the data if it is a String or Buffer
+    // Create a stream from the data if it is a String or Buffer.
     if (data instanceof Buffer || typeof data === 'string') {
       stream = streamifier.createReadStream(data)
     } else if (data instanceof Stream) {
       stream = data
     }
 
-    stream.pipe(cacheFile)
-  }).then(result => {
-    if (!options.metadata) {
-      return result
-    }
+    // Adding to database.
+    let lastModified = Date.now()
 
-    return this.setMetadata(key, options.metadata).then(() => result)
+    db.insert({
+      $key: key,
+      lastModified,
+      path: cachePath,
+      metadata: options.metadata || null
+    })
+
+    return new Promise((resolve, reject) => {
+      stream.pipe(cacheFile)
+
+      cacheFile.on('finish', () => {
+        return resolve('')
+      }).on('error', err => {
+        return reject(err)
+      })
+    })
   })
 }
 
@@ -307,7 +333,7 @@ FileCache.prototype.cleanseCache = function cleanseCache (dir, done) {
 FileCache.prototype.startDatabase = function () {
   return new Promise((resolve, reject) => {
     let db = new Loki(
-      path.join(__dirname, '../db.json'),
+      path.join(this.directory, 'db.json'),
       {
         autoload: true,
         autoloadCallback: () => {

--- a/lib/file.js
+++ b/lib/file.js
@@ -173,6 +173,10 @@ FileCache.prototype.flush = function (pattern) {
     let matches = db.find({ $key: { $regex: re } })
     let deletedCount = 0
 
+    if (matches.length === 0) {
+      return
+    }
+
     return new Promise((resolve, reject) => {
       let registerDeletion = () => {
         if (++deletedCount === matches.length) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -142,6 +142,7 @@ FileCache.prototype.set = function set (key, data, options) {
 
     db.insert({
       $key: key,
+      $dadiCache: options.metadata || null,
       lastModified,
       path: cachePath,
       metadata: options.metadata || null

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
   },
   "devDependencies": {
     "concat-stream": "^1.6.0",
+    "coveralls": "^3.0.1",
     "env-test": "^1.0.0",
     "fakeredis": "^1.0.3",
     "ink-docstrap": "latest",
     "ioredis-mock": "^1.7.0",
     "istanbul": "^0.4.4",
-    "istanbul-cobertura-badger": "^1.2.1",
     "length-stream": "^0.1.1",
     "mocha": "3.2.x",
     "mock-redis-client": "^0.91.13",

--- a/scripts/coverage.js
+++ b/scripts/coverage.js
@@ -1,44 +1,9 @@
 #! /usr/bin/env node
 
-var fs = require('fs')
-var path = require('path')
+const exec = require('child_process').exec
 
-var coberturaBadger = require('istanbul-cobertura-badger')
-
-var opts = {
-  badgeFileName: 'coverage',
-  destinationDir: __dirname,
-  istanbulReportFile: path.resolve(__dirname + '/../coverage', 'cobertura-coverage.xml'),
-  thresholds: {
-    excellent: 90, // overall percent >= excellent, green badge
-    good: 60 // overall percent < excellent and >= good, yellow badge
-  // overall percent < good, red badge
-  }
-}
-
-// console.log(opts)
-
-// Load the badge for the report$
-coberturaBadger(opts, function parsingResults (err, badgeStatus) {
-  if (err) {
-    console.log('An error occurred: ' + err.message)
-  }
-
-  //console.log(badgeStatus)
-
-  var readme = path.resolve(__dirname + '/../README.md')
-  var badgeUrl = badgeStatus.url; // e.g. http://img.shields.io/badge/coverage-60%-yellow.svg
-
-  // open the README.md and add this url
-  fs.readFile(readme, {encoding: 'utf-8'}, function (err, body) {
-    body = body.replace(/(!\[coverage\]\()(.+?)\?*(\))/g, function (whole, a, b, c) {
-      return a + badgeUrl + c
-    })
-
-    fs.writeFile(readme, body, {encoding: 'utf-8'}, function (err) {
-      if (err) console.log(err.toString())
-
-      console.log('Coverage badge successfully added to ' + readme)
-    })
+if (process.env['CI']) {
+  exec('cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js', (err, out) => {
+    if (err) console.log(err)
   })
-})
+}

--- a/test/integration/redis.js
+++ b/test/integration/redis.js
@@ -72,7 +72,7 @@ describe('RedisCache', function () {
     })
   })
 
-  describe('Non-clustered instance (127.0.0.1:6379)', () => {
+  describe('Clustered instance (127.0.0.1:6379)', () => {
     it.skip('should connect to a redis cluster', (done) => {
       cache = Cache({
         directory: {

--- a/test/unit/file.js
+++ b/test/unit/file.js
@@ -1,23 +1,54 @@
-var exec = require('child_process').exec
-var fs = require('fs')
-var fsExtra = require('fs-extra')
-var path = require('path')
-var should = require('should')
-var sinon = require('sinon')
-var Stream = require('stream')
-var Cache = require(__dirname + '/../../lib/index')
-var FileCache = require(__dirname + '/../../lib/file')
+const Cache = require('./../../lib/index')
+const exec = require('child_process').exec
+const FileCache = require('./../../lib/file')
+const fs = require('fs')
+const fsExtra = require('fs-extra')
+const path = require('path')
+const should = require('should')
+const sinon = require('sinon')
+const Stream = require('stream')
 
 describe('FileCache', function () {
+  beforeEach(done => {
+    exec(`rm -rf cache/*`, (err, y, z) => {
+      done(err)
+    })
+  })
+
   it('should use empty string extension if none is specfied', function () {
-    var cache = new Cache({ directory: { enabled: true, path: './cache' }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-    var handler = cache.cacheHandler
+    let cache = new Cache({
+      directory: {
+        enabled: true,
+        path: './cache'
+      },
+      redis: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 6379
+      }
+    })
+
+    let handler = cache.cacheHandler
+
     return handler.extension.should.eql('')
   })
 
   it('should use extension if one is specfied', function () {
-    var cache = new Cache({ directory: { enabled: true, path: './cache', extension: 'json' }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-    var handler = cache.cacheHandler
+    let cache = new Cache({
+      directory: {
+        enabled: true,
+        path: './cache',
+        extension: 'json'
+      },
+      redis: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 6379
+      }
+    })
+
+    let handler = cache.cacheHandler
+
     return handler.extension.should.eql('.json')
   })
 
@@ -25,60 +56,134 @@ describe('FileCache', function () {
     this.timeout(5000)
 
     beforeEach(function (done) {
-      var setup = function (dir) {
+      let setup = function (dir) {
         return new Promise((resolve, reject) => {
           exec('mkdir ' + dir, (err, y, z) => {
-            // console.log(err)
             return resolve()
           })
         })
       }
 
-      var cache = new Cache({ directory: { enabled: true, path: './cache' }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
+      let cache = new Cache({
+        directory: {
+          enabled: true,
+          path: './cache'
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+
       setTimeout(() => {
         setup(path.resolve(cache.cacheHandler.directory)).then(done)
       }, 2000)
     })
 
+    it('should remove files that match the given pattern and leave the other ones untouched', () => {
+      let cache = new Cache({
+        ttl: 1,
+        directory: {
+          enabled: true,
+          path: './cache',
+          autoFlush: false
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+
+      return cache.set('keyone', 'data').then(() => {
+        return cache.set('keytwo', 'data')
+      }).then(() => {
+        return cache.set('keythree', 'data')
+      }).then(() => {
+        return cache.flush('two')
+      }).then(() => {
+        return cache.get('keyone')
+      }).then(res => {
+        should.exist(res)
+
+        return cache.get('keytwo').catch(err => {
+          should.exist(err)
+          err.message.should.eql(
+            'The specified key does not exist'
+          )
+        })
+      }).then(() => {
+        return cache.get('keyone')
+      }).then(res => {
+        should.exist(res)
+      })
+    })    
+
     it('should use default autoFlush interval if none is specfied', function () {
-      var cache = new Cache({ directory: { enabled: true, path: './cache' }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
+      let cache = new Cache({
+        directory: {
+          enabled: true,
+          path: './cache'
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
 
       cache.cacheHandler.autoFlushInterval.should.not.be.NaN()
       cache.cacheHandler.autoFlushInterval.should.be.above(0)
     })
 
     it('should use autoFlush interval if one is specfied', function () {
-      var specificautoFlushInterval = 600
-      var cache = new Cache({ directory: { enabled: true, path: './cache', autoFlushInterval: specificautoFlushInterval }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
+      let specificautoFlushInterval = 600
+      let cache = new Cache({
+        directory: {
+          enabled: true,
+          path: './cache',
+          autoFlushInterval: specificautoFlushInterval
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
 
       cache.cacheHandler.autoFlushInterval.should.not.be.NaN()
       cache.cacheHandler.autoFlushInterval.should.equal(specificautoFlushInterval)
     })
 
     it('should remove an expired file when cache cleansing is enabled', function (done) {
-      var cache = new Cache({ ttl: 1, directory: { enabled: true, path: './cache', autoFlush: true, autoFlushInterval: 1 }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-      var filePath = path.resolve(path.join(cache.cacheHandler.directory, 'test_file'))
-      fs.writeFileSync(filePath, 'testfile')
+      let cache = new Cache({
+        ttl: 1,
+        directory: {
+          enabled: true,
+          path: './cache',
+          autoFlush: true,
+          autoFlushInterval: 1.5
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
 
-      setTimeout(() => {
-        fs.stat(filePath, (err, stats) => {
-          should.exist(err)
-          should.not.exist(stats)
-          done()
-        })
-      }, 2000)
-    })
-
-    it('should remove empty directories when cache cleansing is finished', function (done) {
-      var cache = new Cache({ ttl: 1, directory: { enabled: true, path: './cache', autoFlush: true, autoFlushInterval: 1 }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-
-      var dir = path.resolve(path.join(cache.cacheHandler.directory, 'test'))
-      exec('mkdir -p ' + dir, (err, y, z) => {
-        var filePath = dir + '/test_file'
-        fs.writeFileSync(filePath, 'testfile')
+      cache.set('key1', 'data').then(() => {
+        let filePath = cache.cacheHandler.directory + '/key1'
 
         setTimeout(() => {
-          fs.stat(dir, (err, stats) => {
+          fs.stat(filePath, (err, stats) => {
+            should.not.exist(err)
+            should.exist(stats)
+          })
+        }, 50)
+
+        setTimeout(() => {
+          fs.stat(filePath, (err, stats) => {
             should.exist(err)
             should.not.exist(stats)
             done()
@@ -87,9 +192,73 @@ describe('FileCache', function () {
       })
     })
 
+    it('should remove empty directories when cache cleansing is finished', function (done) {
+      let cache = new Cache({
+        ttl: 1,
+        directory: {
+          enabled: true,
+          path: './cache',
+          autoFlush: true,
+          autoFlushInterval: 1.5,
+          directoryChunkSize: 3
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+
+      cache.set('onetwothree', 'data').then(() => {
+        let firstLevel = path.resolve(
+          path.join(
+            cache.cacheHandler.directory,
+            'one'
+          )
+        )
+        let filePath = path.join(
+          firstLevel,
+          'two',
+          'thr',
+          'ee',
+          'onetwothree'
+        )
+
+        setTimeout(() => {
+          fs.stat(filePath, (err, stats) => {
+            should.not.exist(err)
+            should.exist(stats)
+            stats.isFile().should.eql(true)
+          })
+        }, 300)
+
+        setTimeout(() => {
+          fs.stat(firstLevel, (err, stats) => {
+            should.exist(err)
+            should.not.exist(stats)
+            done()
+          })
+        }, 4000)
+      })
+    })
+
     it('should not remove an unexpired file when cache cleansing is enabled', function (done) {
-      var cache = new Cache({ ttl: 60, directory: { enabled: true, path: './cache', autoFlush: true, autoFlushInterval: 1 }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-      var filePath = path.resolve(path.join(cache.cacheHandler.directory, 'test_file'))
+      let cache = new Cache({
+        ttl: 60,
+        directory: {
+          enabled: true,
+          path: './cache',
+          autoFlush: true,
+          autoFlushInterval: 1
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+
+      let filePath = path.resolve(path.join(cache.cacheHandler.directory, 'test_file'))
       fs.writeFileSync(filePath, 'testfile')
 
       setTimeout(() => {
@@ -104,10 +273,21 @@ describe('FileCache', function () {
   })
 
   describe('set', function () {
-    var cache = new Cache({ directory: { enabled: true, path: './cache', extension: 'json' }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
+    let cache = new Cache({
+      directory: {
+        enabled: true,
+        path: './cache',
+        extension: 'json'
+      },
+      redis: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 6379
+      }
+    })
 
     beforeEach(function (done) {
-      var setup = function (dir) {
+      let setup = function (dir) {
         return new Promise((resolve, reject) => {
           exec('mkdir ' + dir)
           return resolve()
@@ -118,7 +298,7 @@ describe('FileCache', function () {
     })
 
     afterEach(function () {
-      var files = fs.readdirSync(cache.cacheHandler.directory)
+      let files = fs.readdirSync(cache.cacheHandler.directory)
       files.forEach((file) => {
         try {
           fs.unlinkSync(cache.cacheHandler.directory + '/' + file)
@@ -127,7 +307,7 @@ describe('FileCache', function () {
     })
 
     it('should generate a cache filename from the directory and key', function (done) {
-      var spy = sinon.spy(fs, 'createWriteStream')
+      let spy = sinon.spy(fs, 'createWriteStream')
 
       cache.set('key1', 'data').then(() => {
         spy.firstCall.args[0].should.eql(path.resolve(cache.cacheHandler.directory + '/key1.json'))
@@ -146,7 +326,7 @@ describe('FileCache', function () {
     })
 
     it('should create a cache file when a Buffer is passed', function (done) {
-      var buffer = new Buffer('data')
+      let buffer = new Buffer('data')
       cache.set('key1', buffer).then(() => {
         // check a file exists
         fs.stat(cache.cacheHandler.directory + '/key1.json', (err, stats) => {
@@ -157,7 +337,7 @@ describe('FileCache', function () {
     })
 
     it('should create a cache file when a Stream is passed', function (done) {
-      var stream = new Stream.Readable()
+      let stream = new Stream.Readable()
       stream.push('data')
       stream.push(null)
       cache.set('key1', stream).then(() => {
@@ -325,11 +505,22 @@ describe('FileCache', function () {
   })
 
   describe('get', function () {
-    var cache = new Cache({ directory: { enabled: true, path: './cache', extension: 'json' }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
+    let cache = new Cache({
+      directory: {
+        enabled: true,
+        path: './cache',
+        extension: 'json'
+      },
+      redis: {
+        enabled: false,
+        host: '127.0.0.1',
+        port: 6379
+      }
+    })
 
     after(function () {
       // remove cache folder contents completely, and recreate
-      var cleanup = function (dir) {
+      let cleanup = function (dir) {
         exec('rm -r ' + dir, function (err, stdout, stderr) {
           exec('mkdir ' + dir)
         })
@@ -339,7 +530,7 @@ describe('FileCache', function () {
     })
 
     it('should generate a cache filename from the directory and key', function (done) {
-      var spy = sinon.spy(fs, 'createReadStream')
+      let spy = sinon.spy(fs, 'createReadStream')
 
       cache.set('key1', 'data').then(() => {
         cache.get('key1').then(() => {
@@ -351,11 +542,23 @@ describe('FileCache', function () {
     })
 
     it('should generate a cache path with subdirectories when directoryChunkSize is set', function (done) {
-      var cacheWithChunks = new Cache({ directory: { enabled: true, path: './cache', extension: 'json', directoryChunkSize: 4 }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-      var spy = sinon.spy(fs, 'createReadStream')
+      let cacheWithChunks = new Cache({
+        directory: {
+          enabled: true,
+          path: './cache',
+          extension: 'json',
+          directoryChunkSize: 4
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+      let spy = sinon.spy(fs, 'createReadStream')
 
-      var key = '1073ab6cda4b991cd29f9e83a307f34004ae9327'
-      var expectedPath = path.resolve(cacheWithChunks.cacheHandler.directory + '/1073/ab6c/da4b/991c/d29f/9e83/a307/f340/04ae/9327' + '/1073ab6cda4b991cd29f9e83a307f34004ae9327.json')
+      let key = '1073ab6cda4b991cd29f9e83a307f34004ae9327'
+      let expectedPath = path.resolve(cacheWithChunks.cacheHandler.directory + '/1073/ab6c/da4b/991c/d29f/9e83/a307/f340/04ae/9327' + '/1073ab6cda4b991cd29f9e83a307f34004ae9327.json')
 
       cacheWithChunks.set(key, 'data')
 
@@ -367,11 +570,23 @@ describe('FileCache', function () {
     })
 
     it('should generate a cache path with uneven-length subdirectories when directoryChunkSize is set', function (done) {
-      var cacheWithChunks = new Cache({ directory: { enabled: true, path: './cache', extension: 'json', directoryChunkSize: 7 }, redis: { enabled: false, host: '127.0.0.1', port: 6379 } })
-      var spy = sinon.spy(fs, 'createReadStream')
+      let cacheWithChunks = new Cache({
+        directory: {
+          enabled: true,
+          path: './cache',
+          extension: 'json',
+          directoryChunkSize: 7
+        },
+        redis: {
+          enabled: false,
+          host: '127.0.0.1',
+          port: 6379
+        }
+      })
+      let spy = sinon.spy(fs, 'createReadStream')
 
-      var key = '1073ab6cda4b991cd29f9e83a307f34004ae9327'
-      var expectedPath = path.resolve(cacheWithChunks.cacheHandler.directory + '/1073ab6/cda4b99/1cd29f9/e83a307/f34004a/e9327' + '/1073ab6cda4b991cd29f9e83a307f34004ae9327.json')
+      let key = '1073ab6cda4b991cd29f9e83a307f34004ae9327'
+      let expectedPath = path.resolve(cacheWithChunks.cacheHandler.directory + '/1073ab6/cda4b99/1cd29f9/e83a307/f34004a/e9327' + '/1073ab6cda4b991cd29f9e83a307f34004ae9327.json')
 
       cacheWithChunks.set(key, 'data')
 


### PR DESCRIPTION
This PR makes the file handler take full advantage of the LokiJS in-memory database, creating an entry for each cached item and reducing 1 disk I/O operation per request. When a request comes in, the key is first checked against the database and if:

- There is a match, a `path` property is obtained from the database record and the file at that location is read and returned as a stream
- There is no match, a cache miss is returned straight away without even going to disk

(cc @mingard @adamkdean)